### PR TITLE
Logging to file without overhead

### DIFF
--- a/docs/jormungandr_node_setup_guide.md
+++ b/docs/jormungandr_node_setup_guide.md
@@ -521,12 +521,6 @@ cargo install --path jcli --force
 chmod +x ./scripts/bootstrap
 ```
 
-### Create directory & file for logging
-```
-mkdir ~/logs
-touch ~/logs/node.out
-```
-
 ### Measure trusted peer latency
 ```
 # Make note of the ip addresses with the shortest response time (end of each line, measured in ms)
@@ -541,9 +535,10 @@ nano ~/files/node-config.yaml
 (replace placeholders with appropriate values)
 ```
 log:
-- output: stderr
-  format: plain
+- format: plain
   level: info
+  output:
+    file: "/var/log/jormungandr.log"  
 p2p:
   topics_of_interest:
     blocks: high


### PR DESCRIPTION
There is no need to log to a file using `>> ~/logs/node.out 2>&1 &` and creating additional overhead when there is a standard way to log directly to the file. 

Also, I believe that it is better to log to the usual location `/var/log`, but that is optional I guess.